### PR TITLE
Silence GeoIP "not found" Errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 /geoip
+/.vs
+/.gitignore
+/.gitignore
+/.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,2 @@
 /geoip
 /.vs
-/.gitignore
-/.gitignore
-/.gitignore

--- a/plugins/processors/geoip/geoip.go
+++ b/plugins/processors/geoip/geoip.go
@@ -53,7 +53,9 @@ func (g *GeoIP) Apply(metrics ...telegraf.Metric) []telegraf.Metric {
 				if value, ok := point.GetField(lookup.Field); ok {
 					record, err := reader.Lookup(net.ParseIP(value.(string)))
 					if err != nil {
-						g.Log.Errorf("GeoIP lookup error: %v", err)
+						if err.Error() != "not found"{
+							g.Log.Errorf("GeoIP lookup error: %v", err)
+						}						
 						continue
 					}
 					if len(lookup.DestCountry) > 0 {


### PR DESCRIPTION
For local addresses, i.e. 192.168.0.0/16 or Docker internal subnets, GeoIP will return a "not found" error. This prints to stdout which in turn ends up in the Docker container logs and makes a bit of a mess. Dropping out this error specifically should be fine.

![image](https://github.com/a-bali/telegraf-geoip/assets/9924637/7443726b-e05a-41b7-b0f4-ec1772be4e72)
